### PR TITLE
Fix full clean on label change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
 	<groupId>org.jenkins-ci.plugins</groupId>    
 	<artifactId>plugin</artifactId>    
-	<version>1.625.3</version>
+	<version>1.628</version>
   </parent>  
   
   <artifactId>integrity-plugin</artifactId>
@@ -194,17 +194,16 @@
     </plugins>
   </build>
   
-  <repositories>
-	<repository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/</url>
-	</repository>
-  </repositories>
-
-  <pluginRepositories>
-	<pluginRepository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/</url>
-	</pluginRepository>
-  </pluginRepositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/hudson/scm/DerbyUtils.java
+++ b/src/main/java/hudson/scm/DerbyUtils.java
@@ -1369,12 +1369,14 @@ public class DerbyUtils
       // Create the select statement for the current project
       checksumSelect = db.prepareStatement(DerbyUtils.CHECKSUM_UPDATE.replaceFirst("CM_PROJECT", projectCacheTable), ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
       rs = checksumSelect.executeQuery();
+      LOGGER.finer(String.format("Updating checksums for table: %s", rs.toString()));
       while (rs.next())
       {
         Hashtable<CM_PROJECT, Object> rowHash = DerbyUtils.getRowData(rs);
         String newChecksum = checksumHash.get(rowHash.get(CM_PROJECT.NAME).toString());
         if (null != newChecksum && newChecksum.length() > 0)
         {
+          LOGGER.finer(String.format("Updating checksum for rowHash: %s newChecksum: %s", rowHash.toString(), newChecksum));
           rs.updateString(CM_PROJECT.CHECKSUM.toString(), newChecksum);
           rs.updateRow();
         }

--- a/src/main/java/hudson/scm/IntegrityCheckoutTask.java
+++ b/src/main/java/hudson/scm/IntegrityCheckoutTask.java
@@ -214,6 +214,8 @@ public class IntegrityCheckoutTask implements FileCallable<Boolean>
           {
             LOGGER.fine("Attempting to restore changed workspace file: "
                 + targetFile.getAbsolutePath() + " to revision " + memberRev);
+            listener.getLogger().println("Attempting to restore changed workspace file: "
+                + targetFile.getAbsolutePath() + " to revision " + memberRev);
             coThreads.add(executor.submit(new CheckOutTask(generateAPISession, openFileHandler,
                 memberName, configPath, memberID, memberRev, memberTimestamp, targetFile, false)));
             fetchCount++;
@@ -245,6 +247,10 @@ public class IntegrityCheckoutTask implements FileCallable<Boolean>
                 .println("Failed to clean up workspace file " + targetFile.getAbsolutePath() + "!");
             return false;
           }
+        }
+        else {
+          LOGGER.warning(String.format("Unexpected deltaFlag %d for file %s and revision %s", deltaFlag,
+              targetFile.getAbsolutePath(), memberRev));
         }
       }
 
@@ -487,6 +493,7 @@ public class IntegrityCheckoutTask implements FileCallable<Boolean>
         openFileHandler.set(openFileHandler.get() + 1);
         if (calculateChecksum)
         {
+          LOGGER.finer(String.format("Put checksum for memberName: %s", memberName));
           checksumHash.put(memberName, IntegrityCMMember.getMD5Checksum(targetFile));
         }
       } else

--- a/src/main/java/hudson/scm/IntegritySCM.java
+++ b/src/main/java/hudson/scm/IntegritySCM.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.sql.ConnectionPoolDataSource;
@@ -904,7 +905,11 @@ public class IntegritySCM extends AbstractIntegritySCM implements Serializable
   }
 
   private String getSource(EnvVars env) {
-      return env.expand(configPath);
+    // pattern for #b=<build> and #d=<devpath> as they are some variant of a project
+    Pattern variant_pattern = Pattern.compile("(#b=[a-zA-Z_0-9\\.]+|#d=[^#]+)");
+    // demystify source by removing the labels/checkpoints/variants as long as path is the same we can be
+    // pretty sure it's still the same project.
+    return String.join("", variant_pattern.split(env.expand(configPath)));
   }
 
   @Override public String getKey() {


### PR DESCRIPTION
 Fix doing clean builds when changing checkpoint

As configPath is used to decide if workspace contains proper repository
changing #b=1.2 into #b=1.3 was triggering a full clean copy which for some
repositories might be gigabytes on every build.
This change allows to utilize a self made checkpoints in builds by
removing checkpoint/label from configPath for the part which identifies
build origin.