### PR TITLE
FIXED JENKINS-52899

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,17 +194,16 @@
     </plugins>
   </build>
   
-  <repositories>
-	<repository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/</url>
-	</repository>
-  </repositories>
-
-  <pluginRepositories>
-	<pluginRepository>
-		<id>repo.jenkins-ci.org</id>
-		<url>http://repo.jenkins-ci.org/</url>
-	</pluginRepository>
-  </pluginRepositories>
+	<repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/hudson/scm/localclient/IntegrityResyncSandboxTask.java
+++ b/src/main/java/hudson/scm/localclient/IntegrityResyncSandboxTask.java
@@ -54,6 +54,11 @@ public class IntegrityResyncSandboxTask implements FilePath.FileCallable<Boolean
         try (ISession session = sandboxUtil.getLocalAPISession()){
             listener.getLogger()
                             .println("[LocalClient] Executing IntegrityResyncSandboxTask :"+ workspaceFile);
+            if (cleanCopy)
+            {
+              workspace.deleteContents();
+              listener.getLogger().println("[LocalClient] Populating clean workspace...");
+            }
             return sandboxUtil.resyncSandbox(session, workspace, cleanCopy, deleteNonMembers, restoreTimestamp, changeLogFile, includeList, excludeList, sandboxScope);
         } catch (Exception e) {
 


### PR DESCRIPTION
I have just upgraded to Plugin 2.2, and we have had build fail, because they rely on the workspace being cleaned before checkout. This worked fine before, but now with the localClient setting = true, we are finding that the workspace is not being cleaned, files from previous builds are still in the workspace after checkout.

I have reproduced this issue and it seems to be consistent. I created a simply Pipeline task, the script performs a checkout of a project just containing a few files and the checkout step is configured with the following settings:

localClient:true, checkpointBeforeBuild: false,  cleanCopy: true, deleteNonMembers: false, fetchChangedWorkspaceFiles: false, restoreTimestamp: false, skipAuthorInfo: false

I start by deleting the workspace on the master and configure the job to do a checkout as local client.

I then manually added a folder and file to the workspace.

I then rerun the task. I observe that despite the clean workspace option being set, the file I added is not deleted.
