### PR TITLE
Jenkins build doesn't fail on APIException during checkin- failure

### DIFF
--- a/src/main/java/hudson/scm/IntegritySCMCheckinNotifierStep.java
+++ b/src/main/java/hudson/scm/IntegritySCMCheckinNotifierStep.java
@@ -15,6 +15,7 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.api.ExceptionHandler;
+import hudson.scm.api.Retrier;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import jenkins.tasks.SimpleBuildStep;
@@ -54,62 +55,68 @@ public class IntegritySCMCheckinNotifierStep extends Notifier implements SimpleB
         .println("Change Package ID will be derived from '" + itemID + "' supplied...");
     String buildID = run.getFullDisplayName();
 
-    try
-    {
-      // Determine what files need to be checked-in
-      FilePath[] artifacts = workspace.list(includes, excludes);
-      if (artifacts.length > 0)
-      {
-        // Create our Change Package for the supplied itemID
-        String cpid =
-            IntegrityCMMember.createCP(ciSettings, itemID, "Build updates from " + buildID);
-        for (int i = 0; i < artifacts.length; i++)
+    // For handling retries
+    Retrier retryHandler = new Retrier(3, 1000);
+    while (true) {
+        try
         {
-          FilePath member = artifacts[i];
-          String relativePath = ("" + member).substring(("" + workspace).length() + 1);
-
-          // This is not a recursive directory tree check-in, only process files found
-          if (!member.isDirectory())
+          // Determine what files need to be checked-in
+          FilePath[] artifacts = workspace.list(includes, excludes);
+          if (artifacts.length > 0)
           {
-            IntegrityCMMember.updateMember(ciSettings, configPath, member, relativePath, cpid,
-                "Build updates from " + buildID);
+            // Create our Change Package for the supplied itemID
+            String cpid =
+                IntegrityCMMember.createCP(ciSettings, itemID, "Build updates from " + buildID);
+            for (int i = 0; i < artifacts.length; i++)
+            {
+              FilePath member = artifacts[i];
+              String relativePath = ("" + member).substring(("" + workspace).length() + 1);
+
+              // This is not a recursive directory tree check-in, only process files found
+              if (!member.isDirectory())
+              {
+                IntegrityCMMember.updateMember(ciSettings, configPath, member, relativePath, cpid,
+                    "Build updates from " + buildID);
+              }
+            }
+
+            // Finally submit the build updates Change Package if its not :none or :bypass
+            if (!cpid.equals(":none") && !cpid.equals(":bypass"))
+            {
+              IntegrityCMMember.submitCP(ciSettings, cpid);
+            } else
+            {
+              IntegrityCMMember.unlockMembers(ciSettings, configPath);
+            }
+
+            // Log the success
+            listener.getLogger().println("Successfully updated Integrity project '" + configPath
+                + WITH_CONTENTS_OF_WS + workspace + ")!");
           }
-        }
 
-        // Finally submit the build updates Change Package if its not :none or :bypass
-        if (!cpid.equals(":none") && !cpid.equals(":bypass"))
+        } catch (InterruptedException iex)
         {
-          IntegrityCMMember.submitCP(ciSettings, cpid);
-        } else
+          LOGGER.severe("Interrupted Exception caught...");
+          listener.getLogger().println("An Interrupted Exception was caught!");
+          LOGGER.log(Level.SEVERE, "InterruptedException", iex);
+          listener.getLogger().println(iex.getMessage());
+          listener.getLogger().println("Failed to update Integrity project '" + configPath
+              + WITH_CONTENTS_OF_WS + workspace + ")!");
+          throw iex;
+        } catch (APIException aex)
         {
-          IntegrityCMMember.unlockMembers(ciSettings, configPath);
-        }
-
-        // Log the success
-        listener.getLogger().println("Successfully updated Integrity project '" + configPath
-            + WITH_CONTENTS_OF_WS + workspace + ")!");
-      }
-
-    } catch (InterruptedException iex)
-    {
-      LOGGER.severe("Interrupted Exception caught...");
-      listener.getLogger().println("An Interrupted Exception was caught!");
-      LOGGER.log(Level.SEVERE, "InterruptedException", iex);
-      listener.getLogger().println(iex.getMessage());
-      listener.getLogger().println("Failed to update Integrity project '" + configPath
-          + WITH_CONTENTS_OF_WS + workspace + ")!");
-      throw iex;
-    } catch (APIException aex)
-    {
-      LOGGER.severe("API Exception caught...");
-      listener.getLogger().println("An API Exception was caught!");
-      ExceptionHandler eh = new ExceptionHandler(aex);
-      LOGGER.severe(eh.getMessage());
-      listener.getLogger().println(eh.getMessage());
-      listener.getLogger().println("Failed to update Integrity project '" + configPath
-          + WITH_CONTENTS_OF_WS + workspace + ")!");
-      LOGGER.fine(eh.getCommand() + " returned exit code " + eh.getExitCode());
-      LOGGER.log(Level.SEVERE, "APIException", aex);
-    }
+          LOGGER.severe("API Exception caught...");
+          listener.getLogger().println("An API Exception was caught!");
+          ExceptionHandler eh = new ExceptionHandler(aex);
+          LOGGER.severe(eh.getMessage());
+          listener.getLogger().println(eh.getMessage());
+          listener.getLogger().println("Failed to update Integrity project '" + configPath
+              + WITH_CONTENTS_OF_WS + workspace + ")!");
+          LOGGER.fine(eh.getCommand() + " returned exit code " + eh.getExitCode());
+          LOGGER.log(Level.SEVERE, "APIException", aex);    
+          retryHandler.exceptionOccurred();
+          continue;
+        }        
+     }
   }
 }

--- a/src/main/java/hudson/scm/api/Retrier.java
+++ b/src/main/java/hudson/scm/api/Retrier.java
@@ -1,0 +1,63 @@
+package hudson.scm.api;
+
+/**
+ * This class is implemented to handle an exception o reaching maximum number of retries
+ */
+public class Retrier {
+    public static final int MAX_RETRIES = 5;
+    public static final long TIME_TO_WAIT_MS = 1000;
+
+    private int maxRetries;
+    private long timeToWaitMS;
+
+    // CONSTRUCTORS
+    public Retrier(int argMaxRetries, long argTimeToWaitMS)
+    {
+    	maxRetries = argMaxRetries;
+        timeToWaitMS = argTimeToWaitMS;
+    }
+
+    public Retrier()
+    {
+        this(MAX_RETRIES, TIME_TO_WAIT_MS);
+    }
+
+    /**
+     * Returns true if a retry can be attempted.
+     * @return true if retries attempts remain 
+     *         else false
+     */
+    public boolean shouldRetry()
+    {
+        return (maxRetries >= 0);
+    }
+
+    /**
+     * Waits for timeToWaitMS. 
+     * Ignores any interrupted exception
+     */
+    public void waitUntilNextTry()
+    {
+        try {
+            Thread.sleep(timeToWaitMS);
+        }
+        catch (InterruptedException iex) { }
+    }
+
+    /**
+     * Call when an exception has occurred in the block. If the
+     * retry limit is exceeded, throws an exception.
+     * Else waits for the specified time.
+     * 
+     * @throws Exception
+     */
+    public void exceptionOccurred() throws InterruptedException
+    {
+        maxRetries--;
+        if(!shouldRetry())
+        {
+            throw new InterruptedException("Retry limit exceeded.");
+        }
+        waitUntilNextTry();
+    }
+}


### PR DESCRIPTION
Jenkins build was successful even if check failed.
There are few cases which results in Jenkins build failure as a part of this changes:

1. Check-in tried on project which doesn't exists and ran into API Exception
2. Check-in tried on project which exists and ran into API Exception